### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It comes with a WSSE Auth Plugin that can be used optionally.
 GuzzleBundle follows semantic versioning. Read more on [semver.org][2].
 
 ## Requirements
- - PHP 5.4 or above
+ - PHP 5.5.0 or above
  - [Guzzle PHP Framework][1] (included by composer)
  - [WSSE Auth Plugin][3] (included by composer)
 


### PR DESCRIPTION
According to the doc, it seems that Guzzle now requires PHP >= 5.5.0:
http://docs.guzzlephp.org/en/latest/overview.html#requirements