### PR TITLE
Added support for Guzzle client options + configuration test

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -77,6 +77,11 @@ class Configuration implements ConfigurationInterface {
         $builder = new TreeBuilder();
         $node    = $builder->root('clients');
 
+        // Filtering function to cast scalar values to boolean
+        $boolFilter = function ($value) {
+            return (bool)$value;
+        };
+
         $node->useAttributeAsKey('name')
              ->prototype('array')
                  ->children()
@@ -85,6 +90,48 @@ class Configuration implements ConfigurationInterface {
                      ->arrayNode('headers')
                          ->prototype('scalar')
                          ->end()
+                     ->end()
+
+                     ->arrayNode('options')
+                         ->children()
+                             ->scalarNode('cert')->end()
+                             ->scalarNode('connect_timeout')->end()
+                             ->booleanNode('debug')
+                                 ->beforeNormalization()
+                                     ->ifString()->then($boolFilter)
+                                 ->end()
+                             ->end()
+                             ->booleanNode('decode_content')
+                                 ->beforeNormalization()
+                                     ->ifString()->then($boolFilter)
+                                 ->end()
+                             ->end()
+                             ->scalarNode('delay')->end()
+                             ->booleanNode('http_errors')
+                                 ->beforeNormalization()
+                                     ->ifString()->then($boolFilter)
+                                 ->end()
+                             ->end()
+                             ->scalarNode('expect')->end()
+                             ->scalarNode('ssl_key')->end()
+                             ->booleanNode('stream')
+                                 ->beforeNormalization()
+                                     ->ifString()->then($boolFilter)
+                                 ->end()
+                             ->end()
+                             ->booleanNode('synchronous')
+                                 ->beforeNormalization()
+                                     ->ifString()->then($boolFilter)
+                                 ->end()
+                             ->end()
+                             ->scalarNode('timeout')->end()
+                             ->booleanNode('verify')
+                                 ->beforeNormalization()
+                                     ->ifString()->then($boolFilter)
+                                 ->end()
+                             ->end()
+                             ->scalarNode('version')->end()
+                          ->end()
                      ->end()
 
                      ->arrayNode('plugin')

--- a/DependencyInjection/GuzzleExtension.php
+++ b/DependencyInjection/GuzzleExtension.php
@@ -58,6 +58,11 @@ class GuzzleExtension extends Extension {
                 'handler'  => $this->createHandler($container, $name, $options)
             ];
 
+            // If present, add default options to the constructor argument for the Guzzle client
+            if (array_key_exists('options', $options)) {
+                $argument = array_merge($options['options'], $argument);
+            }
+
             $client = new Definition($container->getParameter('guzzle.http_client.class'));
             $client->addArgument($argument);
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ guzzle:
             headers:
                 Accept: "application/json"
 
+            # guzzle client options (full description here: http://guzzle.readthedocs.org/en/latest/request-options.html)
+            # NOTE: "headers" option is not accepted here as it is provided as described above.
+            options:
+                timeout: 30
+
             # plugin settings
             plugin:
                 wsse:

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection;
 
 use       EightPoints\Bundle\GuzzleBundle\DependencyInjection\Configuration;
+use       Symfony\Component\Config\Definition\Processor;
 
 /**
  * Class ConfigurationTest
@@ -15,8 +16,45 @@ use       EightPoints\Bundle\GuzzleBundle\DependencyInjection\Configuration;
  */
 class ConfigurationTest extends \PHPUnit_Framework_TestCase {
 
-    public function test() {
+    public function testSingleClientConfigWithOptions()
+    {
+        $config = [
+            'guzzle' => [
+                'clients' => [
+                    'test_client' => [
+                        'base_url' => 'http://baseurl/path',
+                        'headers' => [
+                            'Accept' => 'application/json'
+                        ],
+                        'options' => [
+                            'cert' => 'path/to/cert',
+                            'connect_timeout' => 5,
+                            'debug' => false,
+                            'decode_content' => true,
+                            'delay' => 1,
+                            'http_errors' => false,
+                            'expect' => true,
+                            'ssl_key' => 'key',
+                            'stream' => true,
+                            'synchronous' => true,
+                            'timeout' => 30,
+                            'verify' => true,
+                            'version' => '1.1'
+                        ],
+                        'plugin' => [
+                            'wsse' => [
+                                'username' => 'user',
+                                'password' => 'pass'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
 
-        $this->markTestSkipped('implement me');
+        $processor = new Processor();
+        $processedConfig = $processor->processConfiguration(new Configuration(true), $config);
+
+        $this->assertEquals(array_merge($config['guzzle'], [ 'logging' => false ]), $processedConfig);
     }
 } // end: ConfigurationTest

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,13 @@
   "require": {
     "php":                                ">=5.5.0",
     "guzzlehttp/guzzle":                  "~6.0",
-    "eightpoints/guzzle-wsse-middleware": "~3.0"
+    "eightpoints/guzzle-wsse-middleware": "~3.0",
+    "symfony/http-kernel":                "~2.3",
+    "psr/log":                            "~1.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "*",
+    "symfony/config": "*"
   },
   "target-dir": "EightPoints/Bundle/GuzzleBundle",
   "autoload": {


### PR DESCRIPTION
Hi! First of all, thanks for the great bundle.

Since there was no way to provide custom default options when instantiating clients (documentation here: http://guzzle.readthedocs.org/en/latest/request-options.html) I added it. I also added a test for the options array I introduced.

@florianpreusner: can you please consider merging this, or let me know if there's anything you don't like? Thanks!

PS: I had to add some dependencies to your composer.json which are in fact real dependencies but were missing after a fresh install. Without them I wasn't able to run tests on my machine. I made sure to add them with a non-strict version requirement so it shouldn't cause problems to anyone already using this bundle.