### PR TITLE
Allow Symfony 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
     "php":                                ">=5.5.0",
     "guzzlehttp/guzzle":                  "~6.0",
     "eightpoints/guzzle-wsse-middleware": "~3.0",
-    "symfony/http-kernel":                "~2.3",
+    "symfony/http-kernel":                "~2.3|~3.0",
     "psr/log":                            "~1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "*",
-    "symfony/config": "*"
+    "symfony/config": "~2.3|~3.0"
   },
   "target-dir": "EightPoints/Bundle/GuzzleBundle",
   "autoload": {


### PR DESCRIPTION
Currently, Symfony 3 is marked as incompatible in the composer.json file. I don't see a reason for this – at least on my machine, the bundle works with 3.0. The toolbar icon is a bit too dark for the new 2.8/3.0 toolbar, though.

Since this bundle keeps us from upgrading to Symfony 3, it would be great if you could tag a Symfony 3.0 compatible release.