### PR TITLE
Drop PHP 5.5 support, stick to PHPUnit <= 5.4; #55

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - hhvm
@@ -26,5 +25,4 @@ notifications:
 matrix:
     allow_failures:
         - env: SYMFONY_VERSION=dev-master
-        - php: 7.0
         - php: nightly

--- a/Tests/DependencyInjection/GuzzleExtensionTest.php
+++ b/Tests/DependencyInjection/GuzzleExtensionTest.php
@@ -63,7 +63,7 @@ class GuzzleExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
-        $container->set('event_dispatcher', $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
+        $container->set('event_dispatcher', $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
 
         return $container;
     }

--- a/Tests/Events/PostTransactionEventTest.php
+++ b/Tests/Events/PostTransactionEventTest.php
@@ -21,7 +21,7 @@ class PostTransactionEventTest extends \PHPUnit_Framework_TestCase
     public function testConstruct()
     {
         $serviceName = 'service name';
-        $response    = $this->getMock('GuzzleHttp\Psr7\Response');
+        $response    = $this->createMock('GuzzleHttp\Psr7\Response');
         $postEvent   = new PostTransactionEvent($response, $serviceName);
 
         $this->assertSame($serviceName, $postEvent->getServiceName());
@@ -39,7 +39,7 @@ class PostTransactionEventTest extends \PHPUnit_Framework_TestCase
     public function testTranscation()
     {
         $statusCode = 204;
-        $response   = $this->getMock('GuzzleHttp\Psr7\Response');
+        $response   = $this->createMock('GuzzleHttp\Psr7\Response');
         $postEvent  = new PostTransactionEvent($response, null);
 
         $transMock = $this->getMockBuilder('GuzzleHttp\Psr7\Response')

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     }
   ],
   "require": {
-    "php":                                ">=5.5.0",
+    "php":                                ">=5.6",
     "guzzlehttp/guzzle":                  "~6.0",
     "eightpoints/guzzle-wsse-middleware": "~4.0",
     "symfony/dependency-injection":       "~2.3|~3.0",
@@ -36,8 +36,8 @@
     "psr/log":                            "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "*",
-    "symfony/config": "~2.3|~3.0"
+    "phpunit/phpunit": "~5.4",
+    "symfony/config":  "2.3|~3.0"
   },
   "target-dir": "EightPoints/Bundle/GuzzleBundle",
   "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [yes]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | [#55]
| License       | MIT
| Doc PR        | []