### PR TITLE
Update Logger.php

### DIFF
--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -40,7 +40,7 @@ class Logger implements LoggerInterface
                 $logMessage->setRequest(new LogRequest($context['request']));
             }
 
-            if (array_key_exists('response', $context)) {
+            if (isset($context['request'])) {
                 $logMessage->setResponse(new LogResponse($context['response']));
             }
         }

--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -36,11 +36,11 @@ class Logger implements LoggerInterface
         $logMessage->setLevel($level);
 
         if ($context) {
-            if (array_key_exists('request', $context)) {
+            if (isset($context['request'])) {
                 $logMessage->setRequest(new LogRequest($context['request']));
             }
 
-            if (isset($context['request'])) {
+            if (isset($context['response'])) {
                 $logMessage->setResponse(new LogResponse($context['response']));
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

$context['request'] could be null (i.e. when the requested URL could not be resolved - DNS-wise)
Which results in:

Type error: Argument 1 passed to EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct() must be an instance of Psr\Http\Message\ResponseInterface, null given