### PR TITLE
Check context response existence before logging it

### DIFF
--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -40,7 +40,7 @@ class Logger implements LoggerInterface
                 $logMessage->setRequest(new LogRequest($context['request']));
             }
 
-            if (isset($context['response']) && !empty($context['response'])) {
+            if (!empty($context['response'])) {
                 $logMessage->setResponse(new LogResponse($context['response']));
             }
         }

--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -40,7 +40,7 @@ class Logger implements LoggerInterface
                 $logMessage->setRequest(new LogRequest($context['request']));
             }
 
-            if (isset($context['response'])) {
+            if (isset($context['response']) && null != $context['response']) {
                 $logMessage->setResponse(new LogResponse($context['response']));
             }
         }

--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -36,7 +36,7 @@ class Logger implements LoggerInterface
         $logMessage->setLevel($level);
 
         if ($context) {
-            if (isset($context['request'])) {
+            if (!empty($context['request'])) {
                 $logMessage->setRequest(new LogRequest($context['request']));
             }
 

--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -40,7 +40,7 @@ class Logger implements LoggerInterface
                 $logMessage->setRequest(new LogRequest($context['request']));
             }
 
-            if (isset($context['response']) && null != $context['response']) {
+            if (isset($context['response']) && empty($context['response'])) {
                 $logMessage->setResponse(new LogResponse($context['response']));
             }
         }

--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -40,7 +40,7 @@ class Logger implements LoggerInterface
                 $logMessage->setRequest(new LogRequest($context['request']));
             }
 
-            if (isset($context['response']) && empty($context['response'])) {
+            if (isset($context['response']) && !empty($context['response'])) {
                 $logMessage->setResponse(new LogResponse($context['response']));
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?          | yes
| New feature?  | no
| BC breaks?     | no
| Deprecations? | no
| Tests pass?     | yes
| License            | MIT

Sometimes when i try to access a page, i get this error : 
`Argument 1 passed to EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct() must be an instance of Psr\Http\Message\ResponseInterface, null given, called in /path/to/bundle/GuzzleBundle/Log/Logger.php on line 44`
Refreshing the page does not repeat the error (making it hard to reproduce).

I don't know why this append.
I fixed it by checking not null $context['response'] but it might be interesting to look for root problem.

Does anyone have an idea ?

Thank you.
