### PR TITLE
VarCI: Added rule to remove invalid label on reopen

### DIFF
--- a/.varci.yml
+++ b/.varci.yml
@@ -20,3 +20,9 @@ ruleset:
             @{{ user.login }}, the issue description is too short. Please reopen it
             once you have amended the description to contain more than the requirement
             of 50 characters.
+
+    remove_label_invalid_on_reopen:
+        name:   "Remove `invalid` label when issues/PRs are reopened"
+        events: [ issues, pull_request ]
+        label:  -invalid
+        when:   action = "reopened"


### PR DESCRIPTION
- [ ] Bug fix
- [x] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Fixed tickets: none
License: MIT

