### PR TITLE
Fix $response->getBody()->getContents() returns always empty content #48

### DIFF
--- a/Log/LogResponse.php
+++ b/Log/LogResponse.php
@@ -60,17 +60,11 @@ class LogResponse
     {
         $this->setStatusCode($response->getStatusCode());
         $this->setStatusPhrase($response->getReasonPhrase());
+        $this->setBody($response->getBody()->getContents());
 
-        // rewind to previous position after response body
-        $readPosition = null;
-        if($response->getBody()->isSeekable()) {
-            $readPosition = $response->getBody()->tell();
-        }
-
-        $this->setBody($response->getBody()->__toString());
-
-        if($readPosition) {
-            $response->getBody()->seek($readPosition);
+        // rewind to previous position after reading response body
+        if ($response->getBody()->isSeekable()) {
+            $response->getBody()->rewind();
         }
 
         $this->setHeaders($response->getHeaders());

--- a/Tests/Log/LogResponseTest.php
+++ b/Tests/Log/LogResponseTest.php
@@ -41,7 +41,7 @@ class LogResponseTest extends \PHPUnit_Framework_TestCase
                          ->disableOriginalConstructor()
                          ->getMock();
 
-        $bodyMock->method('__toString')->willReturn('test body');
+        $bodyMock->method('getContents')->willReturn('test body');
 
         $this->response->method('getStatusCode')->willReturn(200);
         $this->response->method('getHeaders')->willReturn($this->headers);


### PR DESCRIPTION
- [x] Bug fix
- [ ] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Fixed tickets: #48 
License: MIT

