### PR TITLE
Improve web profiler toolbar v2 integration

### DIFF
--- a/Resources/views/debug.html.twig
+++ b/Resources/views/debug.html.twig
@@ -2,18 +2,29 @@
 
 
 {% block toolbar %}
+    {% set profiler_markup_version = profiler_markup_version|default(1) %}
+
     {% if collector.callCount %}
         {% if collector.errorCount %}
             {% set color = 'red' %}
         {% else %}
             {% set color = 'green' %}
         {% endif %}
+        {% set status_color = collector.errorCount ? 'red' : 'normal' %}
 
         {% set icon %}
-            {{ include("@Guzzle/Icons/logo.svg.twig") }}
-            <span class="sf-toolbar-status sf-toolbar-status-{{ color }}">
-                {{ collector.callCount }}
-            </span>
+            {# Symfony <2.8 toolbar #}
+            {% if profiler_markup_version == 1 %}
+                {{ include("@Guzzle/Icons/logo.svg.twig") }}
+                <span class="sf-toolbar-status sf-toolbar-status-{{ color }}">
+                    {{ collector.callCount }}
+                </span>
+            {% else %}
+                {{ include("@Guzzle/Icons/logo.svg.twig") }}
+                <span class="sf-toolbar-value">
+                   {{ collector.callCount }}
+                </span>
+            {% endif %}
         {% endset %}
 
         {% set text %}
@@ -33,7 +44,7 @@
             </div>
         {% endset %}
 
-        {% include "WebProfilerBundle:Profiler:toolbar_item.html.twig" with { "link": profiler_url } %}
+        {% include "WebProfilerBundle:Profiler:toolbar_item.html.twig" with { "link": profiler_url, status: status_color } %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
* The SVG icon is now correctly aligned
* No green color anymore when calls are made to be compliant with native Symfony's collectors
* Improved errored red status integration
* The old toolbar integration is kept thanks to the profiler_markup_version variable

Before:

![image](https://cloud.githubusercontent.com/assets/1698357/21563515/73a421f0-ce83-11e6-9c6a-101e095064b6.png)

After:

![image](https://cloud.githubusercontent.com/assets/1698357/21563543/ab8384bc-ce83-11e6-8472-741e9da989e9.png)

![image](https://cloud.githubusercontent.com/assets/1698357/21563548/b1810448-ce83-11e6-9c87-618efeae2f52.png)

![image](https://cloud.githubusercontent.com/assets/1698357/21563551/b58cc4be-ce83-11e6-8621-c3a8458e877f.png)

- [x] Enhancement
- [x] Tests pass

License: MIT

References:

* http://symfony.com/blog/new-in-symfony-2-8-redesigned-web-debug-toolbar
* https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#webprofiler
