### PR TITLE
Allow cert parameter as array in config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -101,7 +101,14 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')
                                 ->end()
                             ->end()
-                            ->scalarNode('cert')->end()
+                            ->variableNode('cert')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_string($v) && (!is_array($v) || count($v) != 2);
+                                    })
+                                    ->thenInvalid('A string or a two entries array required')
+                                ->end()
+                            ->end()
                             ->scalarNode('connect_timeout')->end()
                             ->booleanNode('debug')
                                 ->beforeNormalization()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -4,6 +4,7 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection;
 
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * @version   2.1
@@ -61,5 +62,88 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $processedConfig = $processor->processConfiguration(new Configuration(true), $config);
 
         $this->assertEquals(array_merge($config['guzzle'], ['logging' => false]), $processedConfig);
+    }
+
+    public function testSingleClientConfigWithCertAsArray()
+    {
+        $config = [
+            'guzzle' => [
+                'clients' => [
+                    'test_client' => [
+                        'base_url' => 'http://baseurl/path',
+                        'headers' => [
+                            'Accept' => 'application/json'
+                        ],
+                        'options' => [
+                            'auth' => [
+                                'user',
+                                'pass'
+                            ],
+                            'headers' => [
+                                'Accept' => 'application/json'
+                            ],
+                            'query' => [
+                            ],
+                            'cert' => [
+                                'path/to/cert',
+                                'password'
+                            ],
+                            'connect_timeout' => 5,
+                            'debug' => false,
+                            'decode_content' => true,
+                            'delay' => 1,
+                            'http_errors' => false,
+                            'expect' => true,
+                            'ssl_key' => 'key',
+                            'stream' => true,
+                            'synchronous' => true,
+                            'timeout' => 30,
+                            'verify' => true,
+                            'version' => '1.1'
+                        ],
+                        'plugin' => [
+                            'wsse' => [
+                                'username' => 'user',
+                                'password' => 'pass',
+                                'created_at' => false
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $processor = new Processor();
+        $processedConfig = $processor->processConfiguration(new Configuration(true), $config);
+
+        $this->assertEquals(array_merge($config['guzzle'], ['logging' => false]), $processedConfig);
+    }
+
+    public function testInvalidCertConfiguration()
+    {
+        $config = [
+            'guzzle' => [
+                'clients' => [
+                    'test_client' => [
+                        'base_url' => 'http://baseurl/path',
+                        'headers' => [
+                            'Accept' => 'application/json'
+                        ],
+                        'options' => [
+                            'cert' => [
+                                'path/to/cert',
+                                'password',
+                                'Invalid'
+                            ],
+                        ],
+                    ]
+                ]
+            ]
+        ];
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $processor = new Processor();
+        $processor->processConfiguration(new Configuration(true), $config);
     }
 }


### PR DESCRIPTION
- [ ] Bug fix
- [x] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Guzzle allows both an array or a string as cert parameter 
https://github.com/guzzle/guzzle/blob/master/src/Handler/CurlFactory.php#L407

License: MIT
