### PR TITLE
Update travis.yml with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
     - 5.6
     - 7.0
-    - hhvm
+    - 7.1
     - nightly
 
 env:
@@ -27,3 +27,16 @@ matrix:
     allow_failures:
         - env: SYMFONY_VERSION=dev-master
         - php: nightly
+    include:
+        - env: SYMFONY_VERSION=2.7.*
+          php: hhvm
+          dist: trusty
+        - env: SYMFONY_VERSION=2.8.*
+          php: hhvm
+          dist: trusty
+        - env: SYMFONY_VERSION=3.0.*
+          php: hhvm
+          dist: trusty
+        - env: SYMFONY_VERSION=3.1.*
+          php: hhvm
+          dist: trusty


### PR DESCRIPTION
As PHP 7.1 is out since December (6 months) I think is useful to test the codebase against it.

- [ ] Bug fix
- [ ] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

License: MIT
