### PR TITLE
Fix configuration processing

### DIFF
--- a/DependencyInjection/GuzzleExtension.php
+++ b/DependencyInjection/GuzzleExtension.php
@@ -40,9 +40,8 @@ class GuzzleExtension extends Extension
 
         $loader->load('services.xml');
 
-        $processor     = new Processor();
         $configuration = new Configuration($this->getAlias(), $container->getParameter('kernel.debug'));
-        $config        = $processor->processConfiguration($configuration, $configs);
+        $config        = $this->processConfiguration($configuration, $configs);
 
         $this->createLogger($config, $container);
 


### PR DESCRIPTION
Not calling the Extension::processConfiguration() method prevents tracking env vars correctly, as spotted in symfony/symfony#24020.