### PR TITLE
Allow clients to have a custom class name

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -79,6 +79,7 @@ class Configuration implements ConfigurationInterface
         $node->useAttributeAsKey('name')
             ->prototype('array')
                 ->children()
+                    ->scalarNode('class')->defaultValue('%guzzle.http_client.class%')->end()
                     ->scalarNode('base_url')->defaultValue(null)->end()
 
                     // @todo @deprecated

--- a/DependencyInjection/GuzzleExtension.php
+++ b/DependencyInjection/GuzzleExtension.php
@@ -65,7 +65,7 @@ class GuzzleExtension extends Extension
                 }
             }
 
-            $client = new Definition('%guzzle.http_client.class%');
+            $client = new Definition($options['class']);
             $client->addArgument($argument);
 
             // set service name based on client name

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -57,7 +57,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                                 'password' => 'pass',
                                 'created_at' => false
                             ]
-                        ]
+                        ],
+						'class' => '%guzzle.http_client.class%',
                     ]
                 ]
             ]
@@ -112,7 +113,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                                 'password' => 'pass',
                                 'created_at' => false
                             ]
-                        ]
+                        ],
+						'class' => '%guzzle.http_client.class%',
                     ]
                 ]
             ]
@@ -180,7 +182,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                                 'password' => 'pass',
                                 'created_at' => false
                             ]
-                        ]
+                        ],
+						'class' => '%guzzle.http_client.class%',
                     ]
                 ]
             ]

--- a/Tests/DependencyInjection/GuzzleExtensionTest.php
+++ b/Tests/DependencyInjection/GuzzleExtensionTest.php
@@ -37,6 +37,11 @@ class GuzzleExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(WsseAuthMiddleware::class, $wsse);
         $this->assertSame('my-user', $wsse->getUsername());
         $this->assertSame('my-pass', $wsse->getPassword());
+		
+        // test Client with custom class
+        $this->assertTrue($container->hasDefinition('guzzle.client.test_api_with_custom_class'));
+        $definition = $container->getDefinition('guzzle.client.test_api_with_custom_class');
+        $this->assertSame('CustomGuzzleClass', $definition->getClass());
     }
 
     public function testOverwriteClasses()
@@ -83,6 +88,9 @@ class GuzzleExtensionTest extends \PHPUnit_Framework_TestCase
                                 'password' => 'my-pass',
                             ],
                         ],
+                    ],
+                    'test_api_with_custom_class' => [
+                        'class' => 'CustomGuzzleClass',
                     ],
                 ],
             ],


### PR DESCRIPTION
- [ ] Bug fix
- [X] New feature
- [ ] BC breaks
- [ ] Deprecations
- [X] Tests pass

License: MIT

Allows you to configure the used class per client. This is esp useful when you use the Auto Wire function in Symfony 3.3.

Simply create a class like this:
```php
<?php

declare(strict_types=1);

namespaceDemoBundle;

use GuzzleHttp\Client;

class PaymentsApiClient extends Client
{

}
```

And then configure your service like this:

```
guzzle:
    clients:
        payments_api:
            class: 'DemoBundle\PaymentsApiClient'
            base_url: '%payments_api_endpoint%'
```

Then you can use `PaymentsApiClient` as a dependency of your Guzzle Service