### PR TITLE
Deprecate PHP 5, add PHP 7 features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: php
 
 php:
-    - 5.6
-    - 7.0
-    - hhvm
+    - 7.1
     - nightly
 
 env:
-    - SYMFONY_VERSION=2.7.*
-    - SYMFONY_VERSION=2.8.*
-    - SYMFONY_VERSION=3.0.*
-    - SYMFONY_VERSION=3.1.*
+    - SYMFONY_VERSION=3.2.*
+    - SYMFONY_VERSION=3.3.*
     - SYMFONY_VERSION=dev-master
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
 
 env:
     - SYMFONY_VERSION=3.2.*
+    - SYMFONY_VERSION=3.3.*
     - SYMFONY_VERSION=dev-master
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
 
 env:
     - SYMFONY_VERSION=3.2.*
-    - SYMFONY_VERSION=3.3.*
     - SYMFONY_VERSION=dev-master
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
     - composer self-update
     - composer require symfony/symfony:${SYMFONY_VERSION}
 
-script: phpunit --coverage-text
+script: ./vendor/bin/phpunit --coverage-text
 
 notifications:
     email:

--- a/DataCollector/HttpDataCollector.php
+++ b/DataCollector/HttpDataCollector.php
@@ -4,9 +4,11 @@ namespace EightPoints\Bundle\GuzzleBundle\DataCollector;
 
 use EightPoints\Bundle\GuzzleBundle\Log\LogGroup;
 use EightPoints\Bundle\GuzzleBundle\Log\LoggerInterface;
+use EightPoints\Bundle\GuzzleBundle\Log\Logger;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Collecting http data for Symfony profiler
@@ -17,14 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 class HttpDataCollector extends DataCollector
 {
 
-    /**
-     * @var \EightPoints\Bundle\GuzzleBundle\Log\Logger $logger
-     */
+    /** @var Logger $logger */
     protected $logger;
 
     /**
-     * Constructor
-     *
      * @version 2.1
      * @since   2014-11
      *
@@ -33,10 +31,10 @@ class HttpDataCollector extends DataCollector
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
-        $this->data = array(
-            'logs' => array(),
+        $this->data = [
+            'logs' => [],
             'callCount' => 0,
-        );
+        ];
     }
 
     /**
@@ -79,7 +77,7 @@ class HttpDataCollector extends DataCollector
      */
     public function getLogs()
     {
-        return array_key_exists('logs', $this->data) ? $this->data['logs'] : array();
+        return array_key_exists('logs', $this->data) ? $this->data['logs'] : [];
     }
 
     /**
@@ -92,12 +90,10 @@ class HttpDataCollector extends DataCollector
      */
     public function getMessages()
     {
-        $messages = array();
+        $messages = [];
 
         foreach ($this->getLogs() as $log) {
-
             foreach ($log->getMessages() as $message) {
-
                 $messages[] = $message;
             }
         }
@@ -152,10 +148,9 @@ class HttpDataCollector extends DataCollector
      * @param   string $id
      * @return  LogGroup
      */
-    protected function getLogGroup($id)
+    protected function getLogGroup(string $id)
     {
         if (!isset($this->data['logs'][$id])) {
-
             $this->data['logs'][$id] = new LogGroup();
         }
 
@@ -173,6 +168,7 @@ class HttpDataCollector extends DataCollector
         if ((float)$this->getSymfonyVersion() >= 2.8) {
             return $this->data['iconColor'] = '#AAAAAA';
         }
+
         return $this->data['iconColor'] = '#3F3F3F';
     }
 
@@ -184,9 +180,10 @@ class HttpDataCollector extends DataCollector
      */
     private function getSymfonyVersion()
     {
-        $symfonyVersion = \Symfony\Component\HttpKernel\Kernel::VERSION;
+        $symfonyVersion = Kernel::VERSION;
         $symfonyVersion = explode('.', $symfonyVersion, -1);
         $symfonyMajorMinorVersion = implode('.', $symfonyVersion);
+
         return $symfonyMajorMinorVersion;
     }
 

--- a/DataCollector/HttpDataCollector.php
+++ b/DataCollector/HttpDataCollector.php
@@ -62,7 +62,7 @@ class HttpDataCollector extends DataCollector
      * @version 2.1
      * @since   2014-11
      */
-    public function getName()
+    public function getName() : string
     {
         return 'guzzle';
     }
@@ -75,7 +75,7 @@ class HttpDataCollector extends DataCollector
      *
      * @return  array $logs
      */
-    public function getLogs()
+    public function getLogs() : array
     {
         return array_key_exists('logs', $this->data) ? $this->data['logs'] : [];
     }
@@ -88,7 +88,7 @@ class HttpDataCollector extends DataCollector
      *
      * @return  array
      */
-    public function getMessages()
+    public function getMessages() : array
     {
         $messages = [];
 
@@ -109,7 +109,7 @@ class HttpDataCollector extends DataCollector
      *
      * @return  integer
      */
-    public function getCallCount()
+    public function getCallCount() : int
     {
         return count($this->getMessages());
     }
@@ -122,7 +122,7 @@ class HttpDataCollector extends DataCollector
      *
      * @return  integer
      */
-    public function getErrorCount()
+    public function getErrorCount() : int
     {
         return 0; //@todo
     }
@@ -134,7 +134,7 @@ class HttpDataCollector extends DataCollector
      *
      * @return float
      */
-    public function getTotalTime()
+    public function getTotalTime() : float
     {
         return 0; //@todo
     }
@@ -148,7 +148,7 @@ class HttpDataCollector extends DataCollector
      * @param   string $id
      * @return  LogGroup
      */
-    protected function getLogGroup(string $id)
+    protected function getLogGroup(string $id) : LogGroup
     {
         if (!isset($this->data['logs'][$id])) {
             $this->data['logs'][$id] = new LogGroup();
@@ -163,7 +163,7 @@ class HttpDataCollector extends DataCollector
      *
      * @return string
      */
-    public final function getIconColor()
+    public final function getIconColor() : string
     {
         if ((float)$this->getSymfonyVersion() >= 2.8) {
             return $this->data['iconColor'] = '#AAAAAA';
@@ -178,7 +178,7 @@ class HttpDataCollector extends DataCollector
      *
      * @return string
      */
-    private function getSymfonyVersion()
+    private function getSymfonyVersion() : string
     {
         $symfonyVersion = Kernel::VERSION;
         $symfonyVersion = explode('.', $symfonyVersion, -1);

--- a/DependencyInjection/Compiler/EventHandlerCompilerPass.php
+++ b/DependencyInjection/Compiler/EventHandlerCompilerPass.php
@@ -4,6 +4,7 @@ namespace EightPoints\Bundle\GuzzleBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 class EventHandlerCompilerPass implements CompilerPassInterface
 {
@@ -17,10 +18,10 @@ class EventHandlerCompilerPass implements CompilerPassInterface
      *
      * @api
      *
-     * @param  \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param  ContainerBuilder $container
      * @return void
      *
-     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function process(ContainerBuilder $container)
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -101,7 +101,14 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')
                                 ->end()
                             ->end()
-                            ->scalarNode('cert')->end()
+                            ->variableNode('cert')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_string($v) && (!is_array($v) || count($v) != 2);
+                                    })
+                                    ->thenInvalid('A string or a two entries array required')
+                                ->end()
+                            ->end()
                             ->scalarNode('connect_timeout')->end()
                             ->booleanNode('debug')
                                 ->beforeNormalization()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,15 +11,10 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-
-    /**
-     * @var string $alias
-     */
+    /** @var string */
     protected $alias;
 
-    /**
-     * @var boolean $debug
-     */
+    /** @var boolean */
     protected $debug;
 
     /**
@@ -29,10 +24,10 @@ class Configuration implements ConfigurationInterface
      * @param   string  $alias
      * @param   boolean $debug
      */
-    public function __construct($alias, $debug = false)
+    public function __construct(string $alias, bool $debug = false)
     {
         $this->alias = $alias;
-        $this->debug = (boolean) $debug;
+        $this->debug = $debug;
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,7 +39,7 @@ class Configuration implements ConfigurationInterface
      * @return  TreeBuilder
      * @throws  \RuntimeException
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder() : TreeBuilder
     {
         $builder = new TreeBuilder();
         $builder->root($this->alias)

--- a/DependencyInjection/GuzzleExtension.php
+++ b/DependencyInjection/GuzzleExtension.php
@@ -2,12 +2,13 @@
 
 namespace EightPoints\Bundle\GuzzleBundle\DependencyInjection;
 
+use EightPoints\Bundle\GuzzleBundle\Log\DevNullLogger;
+use GuzzleHttp\HandlerStack;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\ExpressionLanguage\Expression;
 
@@ -17,8 +18,6 @@ use Symfony\Component\ExpressionLanguage\Expression;
  */
 class GuzzleExtension extends Extension
 {
-    protected $logFormatter;
-
     /**
      * {@inheritdoc}
      */
@@ -43,7 +42,7 @@ class GuzzleExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configPath = implode(DIRECTORY_SEPARATOR, array(__DIR__, '..', 'Resources', 'config'));
+        $configPath = implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'Resources', 'config']);
         $loader     = new XmlFileLoader($container, new FileLocator($configPath));
 
         $loader->load('services.xml');
@@ -93,7 +92,7 @@ class GuzzleExtension extends Extension
      * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
      * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */
-    protected function createHandler(ContainerBuilder $container, $name, array $config)
+    protected function createHandler(ContainerBuilder $container, string $name, array $config)
     {
         $logServiceName = sprintf('guzzle_bundle.middleware.log.%s', $name);
         $log = $this->createLogMiddleware();
@@ -108,11 +107,11 @@ class GuzzleExtension extends Extension
         // Create the event Dispatch Middleware
         $eventExpression  = new Expression(sprintf("service('%s').dispatchEvent()", $eventServiceName));
 
-        $handler = new Definition('GuzzleHttp\HandlerStack');
-        $handler->setFactory(['GuzzleHttp\HandlerStack', 'create']);
+        $handler = new Definition(HandlerStack::class);
+        $handler->setFactory([HandlerStack::class, 'create']);
 
         // Plugins
-        if (isset($config['plugin'])){
+        if (isset($config['plugin'])) {
             // Wsse if required
             if (isset($config['plugin']['wsse'])
                 && $config['plugin']['wsse']['username']
@@ -165,7 +164,7 @@ class GuzzleExtension extends Extension
         if ($config['logging'] === true) {
             $logger = new Definition('%guzzle_bundle.logger.class%');
         } else {
-            $logger = new Definition('EightPoints\Bundle\GuzzleBundle\Log\DevNullLogger');
+            $logger = new Definition(DevNullLogger::class);
         }
 
         $container->setDefinition('guzzle_bundle.logger', $logger);
@@ -198,7 +197,7 @@ class GuzzleExtension extends Extension
      *
      * @return Definition
      */
-    protected function createEventMiddleware($name)
+    protected function createEventMiddleware(string $name)
     {
         $eventMiddleWare = new Definition('%guzzle_bundle.middleware.event_dispatcher.class%');
         $eventMiddleWare->addArgument(new Reference('event_dispatcher'));
@@ -224,7 +223,7 @@ class GuzzleExtension extends Extension
         $wsse->setArguments([$username, $password]);
 
         if ($createdAtExpression) {
-            $wsse->addMethodCall('setCreatedAtTimeExpression', array($createdAtExpression));
+            $wsse->addMethodCall('setCreatedAtTimeExpression', [$createdAtExpression]);
         }
 
         return $wsse;

--- a/DependencyInjection/GuzzleExtension.php
+++ b/DependencyInjection/GuzzleExtension.php
@@ -92,7 +92,7 @@ class GuzzleExtension extends Extension
      * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
      * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */
-    protected function createHandler(ContainerBuilder $container, string $name, array $config)
+    protected function createHandler(ContainerBuilder $container, string $name, array $config) : Definition
     {
         $logServiceName = sprintf('guzzle_bundle.middleware.log.%s', $name);
         $log = $this->createLogMiddleware();
@@ -158,7 +158,7 @@ class GuzzleExtension extends Extension
      *
      * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
      */
-    protected function createLogger(array $config, ContainerBuilder $container)
+    protected function createLogger(array $config, ContainerBuilder $container) : Definition
     {
 
         if ($config['logging'] === true) {
@@ -179,7 +179,7 @@ class GuzzleExtension extends Extension
      *
      * @return Definition
      */
-    protected function createLogMiddleware()
+    protected function createLogMiddleware() : Definition
     {
         $log = new Definition('%guzzle_bundle.middleware.log.class%');
         $log->addArgument(new Reference('guzzle_bundle.logger'));
@@ -197,7 +197,7 @@ class GuzzleExtension extends Extension
      *
      * @return Definition
      */
-    protected function createEventMiddleware(string $name)
+    protected function createEventMiddleware(string $name) : Definition
     {
         $eventMiddleWare = new Definition('%guzzle_bundle.middleware.event_dispatcher.class%');
         $eventMiddleWare->addArgument(new Reference('event_dispatcher'));
@@ -217,7 +217,7 @@ class GuzzleExtension extends Extension
      *
      * @return Definition
      */
-    protected function createWsseMiddleware($username, $password, $createdAtExpression = null)
+    protected function createWsseMiddleware($username, $password, $createdAtExpression = null) : Definition
     {
         $wsse = new Definition('%guzzle_bundle.middleware.wsse.class%');
         $wsse->setArguments([$username, $password]);
@@ -237,7 +237,7 @@ class GuzzleExtension extends Extension
      *
      * @return  string
      */
-    public function getAlias()
+    public function getAlias() : string
     {
         return 'guzzle';
     }

--- a/DependencyInjection/GuzzleExtension.php
+++ b/DependencyInjection/GuzzleExtension.php
@@ -21,7 +21,7 @@ class GuzzleExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container) : Configuration
     {
         return new Configuration($this->getAlias(), $container->getParameter('kernel.debug'));
     }
@@ -53,17 +53,14 @@ class GuzzleExtension extends Extension
         $this->createLogger($config, $container);
 
         foreach ($config['clients'] as $name => $options) {
-
             $argument = [
                 'base_uri' => $options['base_url'],
                 'handler'  => $this->createHandler($container, $name, $options)
             ];
 
             // if present, add default options to the constructor argument for the Guzzle client
-            if (array_key_exists('options', $options) && is_array($options['options'])) {
-
+            if (isset($options['options']) && is_array($options['options'])) {
                 foreach ($options['options'] as $key => $value) {
-
                     if ($value === null || (is_array($value) && count($value) === 0)) {
                         continue;
                     }

--- a/Events/PostTransactionEvent.php
+++ b/Events/PostTransactionEvent.php
@@ -30,7 +30,7 @@ class PostTransactionEvent extends Event
      *
      * @return ResponseInterface
      */
-    public function getTransaction()
+    public function getTransaction() : ResponseInterface
     {
         return $this->response;
     }
@@ -48,7 +48,7 @@ class PostTransactionEvent extends Event
     /**
      * @return string
      */
-    public function getServiceName()
+    public function getServiceName() : string
     {
         return $this->serviceName;
     }

--- a/Events/PostTransactionEvent.php
+++ b/Events/PostTransactionEvent.php
@@ -7,28 +7,21 @@ use Symfony\Component\EventDispatcher\Event;
 
 class PostTransactionEvent extends Event
 {
-    /**
-     * @var ResponseInterface|null
-     */
+    /** @var ResponseInterface|null */
     protected $response;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $serviceName;
 
     /**
-     * PostTransactionEvent constructor.
-     *
-     * @param \Psr\Http\Message\ResponseInterface|null  $response
-     * @param string                                    $serviceName
+     * @param ResponseInterface|null $response
+     * @param string                 $serviceName
      */
-    public function __construct(ResponseInterface $response = null, $serviceName)
+    public function __construct(ResponseInterface $response = null, string $serviceName)
     {
         $this->response = $response;
         $this->serviceName = $serviceName;
     }
-
 
     /**
      * Get the transaction from the event.

--- a/Events/PreTransactionEvent.php
+++ b/Events/PreTransactionEvent.php
@@ -7,23 +7,17 @@ use Symfony\Component\EventDispatcher\Event;
 
 class PreTransactionEvent extends Event
 {
-    /**
-     * @var RequestInterface
-     */
+    /** @var RequestInterface */
     protected $requestTransaction;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $serviceName;
 
     /**
-     * PreTransactionEvent constructor.
-     *
-     * @param \Psr\Http\Message\RequestInterface $requestTransaction
-     * @param string                             $serviceName
+     * @param RequestInterface $requestTransaction
+     * @param string           $serviceName
      */
-    public function __construct(RequestInterface $requestTransaction, $serviceName)
+    public function __construct(RequestInterface $requestTransaction, string $serviceName)
     {
         $this->requestTransaction = $requestTransaction;
         $this->serviceName = $serviceName;
@@ -35,7 +29,7 @@ class PreTransactionEvent extends Event
      * This returns the actual Request Object from the Guzzle HTTP Request.
      * This object will be modified by the event listener.
      *
-     * @return \Psr\Http\Message\RequestInterface
+     * @return RequestInterface
      */
     public function getTransaction()
     {
@@ -49,7 +43,7 @@ class PreTransactionEvent extends Event
      * so once it has been modified, we need to put it back on the
      * event so it can become part of the transaction.
      *
-     * @param \Psr\Http\Message\RequestInterface $requestTransaction
+     * @param RequestInterface $requestTransaction
      */
     public function setTransaction(RequestInterface $requestTransaction)
     {

--- a/Events/PreTransactionEvent.php
+++ b/Events/PreTransactionEvent.php
@@ -31,7 +31,7 @@ class PreTransactionEvent extends Event
      *
      * @return RequestInterface
      */
-    public function getTransaction()
+    public function getTransaction() : RequestInterface
     {
         return $this->requestTransaction;
     }
@@ -53,7 +53,7 @@ class PreTransactionEvent extends Event
     /**
      * @return string
      */
-    public function getServiceName()
+    public function getServiceName() : string
     {
         return $this->serviceName;
     }

--- a/Log/DevNullLogger.php
+++ b/Log/DevNullLogger.php
@@ -39,7 +39,7 @@ class DevNullLogger implements LoggerInterface
      *
      * @return  boolean
      */
-    public function hasMessages()
+    public function hasMessages() : bool
     {
         return false;
     }
@@ -49,7 +49,7 @@ class DevNullLogger implements LoggerInterface
      *
      * @return  array
      */
-    public function getMessages()
+    public function getMessages() : array
     {
         return [];
     }

--- a/Log/LogGroup.php
+++ b/Log/LogGroup.php
@@ -22,7 +22,7 @@ class LogGroup
      *
      * @param   string $value
      */
-    public function setRequestName($value)
+    public function setRequestName(string $value)
     {
         $this->requestName = $value;
     }
@@ -74,7 +74,7 @@ class LogGroup
      *
      * @return  array
      */
-    public function getMessages()
+    public function getMessages() : array
     {
         return $this->messages;
     }

--- a/Log/LogGroup.php
+++ b/Log/LogGroup.php
@@ -8,14 +8,10 @@ namespace EightPoints\Bundle\GuzzleBundle\Log;
  */
 class LogGroup
 {
-    /**
-     * @var array
-     */
-    protected $messages = array();
+    /** @var array */
+    protected $messages = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $requestName;
 
     /**

--- a/Log/LogMessage.php
+++ b/Log/LogMessage.php
@@ -36,11 +36,11 @@ class LogMessage
      *
      * @since  2015-05
      *
-     * @param  string $value
+     * @param  string $level
      */
-    public function setLevel($value)
+    public function setLevel($level)
     {
-        $this->level = $value;
+        $this->level = $level;
     }
 
     /**

--- a/Log/LogMessage.php
+++ b/Log/LogMessage.php
@@ -8,29 +8,19 @@ namespace EightPoints\Bundle\GuzzleBundle\Log;
  */
 class LogMessage
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $message;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $level;
 
-    /**
-     * @var LogRequest
-     */
+    /** @var LogRequest */
     protected $request;
 
-    /**
-     * @var LogResponse
-     */
+    /** @var LogResponse */
     protected $response;
 
     /**
-     * Constructor
-     *
      * @version 2.1
      * @since   2014-11
      *

--- a/Log/LogRequest.php
+++ b/Log/LogRequest.php
@@ -10,59 +10,37 @@ use Psr\Http\Message\RequestInterface;
  */
 class LogRequest
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $host;
 
-    /**
-     * @var integer
-     */
+    /** @var integer */
     protected $port;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $url;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $path;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $scheme;
 
-    /**
-     * @var array
-     */
-    protected $headers = array();
+    /** @var array */
+    protected $headers = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $protocolVersion;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $method;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $body;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $resource;
 
     /**
-     * Construct
-     *
      * @version 2.1
      * @since   2015-05
      *
@@ -96,13 +74,13 @@ class LogRequest
 
         // rewind to previous position after logging request
         $readPosition = null;
-        if($request->getBody() && $request->getBody()->isSeekable()) {
+        if ($request->getBody() && $request->getBody()->isSeekable()) {
             $readPosition = $request->getBody()->tell();
         }
 
         $this->setBody($request->getBody() ? $request->getBody()->__toString() : null);
 
-        if($readPosition) {
+        if ($readPosition) {
             $request->getBody()->seek($readPosition);
         }
     }
@@ -351,7 +329,6 @@ class LogRequest
      */
     public function getResource()
     {
-
         return $this->resource;
     }
 

--- a/Log/LogResponse.php
+++ b/Log/LogResponse.php
@@ -10,34 +10,22 @@ use Psr\Http\Message\ResponseInterface;
  */
 class LogResponse
 {
-    /**
-     * @var integer
-     */
+    /** @var integer */
     protected $statusCode;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $statusPhrase;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $body;
 
-    /**
-     * @var array
-     */
-    protected $headers = array();
+    /** @var array */
+    protected $headers = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $protocolVersion;
 
     /**
-     * Construct
-     *
      * @version 2.1
      * @since   2015-05
      *

--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -64,7 +64,7 @@ class Logger implements LoggerInterface
      *
      * @return  boolean
      */
-    public function hasMessages()
+    public function hasMessages() : bool
     {
         return $this->getMessages() ? true : false;
     }
@@ -77,7 +77,7 @@ class Logger implements LoggerInterface
      *
      * @return  array
      */
-    public function getMessages()
+    public function getMessages() : array
     {
         return $this->messages;
     }

--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -12,10 +12,8 @@ class Logger implements LoggerInterface
 {
     use LoggerTrait;
 
-    /**
-     * @var array
-     */
-    private $messages = array();
+    /** @var array */
+    private $messages = [];
 
     /**
      * Log message
@@ -29,7 +27,7 @@ class Logger implements LoggerInterface
      *
      * @return  void
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = [])
     {
         $logMessage = new LogMessage($message);
         $logMessage->setLevel($level);
@@ -55,7 +53,7 @@ class Logger implements LoggerInterface
      */
     public function clear()
     {
-        $this->messages = array();
+        $this->messages = [];
     }
 
     /**

--- a/Log/LoggerInterface.php
+++ b/Log/LoggerInterface.php
@@ -2,7 +2,7 @@
 
 namespace EightPoints\Bundle\GuzzleBundle\Log;
 
-use Psr\Log;
+use Psr\Log\LoggerInterface as PsrLoggerInterface;
 
 /**
  * Interface LoggerInterface
@@ -10,7 +10,7 @@ use Psr\Log;
  * @author  SuRiKmAn <surikman@surikman.sk>
  * @package EightPoints\Bundle\GuzzleBundle\Log
  */
-interface LoggerInterface extends Log\LoggerInterface
+interface LoggerInterface extends PsrLoggerInterface
 {
 
     /**

--- a/Log/LoggerInterface.php
+++ b/Log/LoggerInterface.php
@@ -25,12 +25,12 @@ interface LoggerInterface extends PsrLoggerInterface
      *
      * @return  boolean
      */
-    public function hasMessages();
+    public function hasMessages() : bool;
 
     /**
      * Return log messages
      *
      * @return  array
      */
-    public function getMessages();
+    public function getMessages() : array;
 }

--- a/Middleware/EventDispatchMiddleware.php
+++ b/Middleware/EventDispatchMiddleware.php
@@ -37,7 +37,7 @@ class EventDispatchMiddleware
     /**
      * @return \Closure
      */
-    public function dispatchEvent()
+    public function dispatchEvent() : \Closure
     {
         return function (callable $handler) {
 

--- a/Middleware/EventDispatchMiddleware.php
+++ b/Middleware/EventDispatchMiddleware.php
@@ -14,23 +14,21 @@ use EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent;
 /**
  * Dispatches an Event using the Symfony Event Dispatcher.
  * Dispatches a PRE_TRANSACTION event, before the transaction is sent
- * Dispatches a POST_TRANMSACTION event, when the remote hosts responds.
+ * Dispatches a POST_TRANSACTION event, when the remote hosts responds.
  */
 class EventDispatchMiddleware
 {
-    /**
-     * @var EventDispatcherInterface
-     */
+    /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
+    /** @var string */
     private $serviceName;
 
     /**
-     * EventDispatchMiddleware constructor.
-     *
      * @param EventDispatcherInterface $eventDispatcher
+     * @param string $serviceName
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher, $serviceName)
+    public function __construct(EventDispatcherInterface $eventDispatcher, string $serviceName)
     {
         $this->eventDispatcher = $eventDispatcher;
         $this->serviceName = $serviceName;

--- a/Middleware/LogMiddleware.php
+++ b/Middleware/LogMiddleware.php
@@ -37,9 +37,9 @@ class LogMiddleware
      * @since   2015-06
      * @version 3.0
      *
-     * @return  callable
+     * @return \Closure
      */
-    public function log()
+    public function log() : \Closure
     {
         $logger    = $this->logger;
         $formatter = $this->formatter;

--- a/Middleware/LogMiddleware.php
+++ b/Middleware/LogMiddleware.php
@@ -12,14 +12,10 @@ use EightPoints\Bundle\GuzzleBundle\Log\LoggerInterface;
  */
 class LogMiddleware
 {
-    /**
-     * @var MessageFormatter
-     */
+    /** @var MessageFormatter */
     protected $formatter;
 
-    /**
-     * @var LoggerInterface
-     */
+    /** @var LoggerInterface */
     protected $logger;
 
     /**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ GuzzleBundle follows semantic versioning. Read more on [semver.org][2].
 ----
 
 ## Requirements
- - PHP 5.6 or above
+ - PHP 7.0 or above
  - Symfony 2.7 or above
  - [Guzzle PHP Framework][1] (included by composer)
  - [WSSE Auth Plugin][3] (included by composer)

--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@
 
 # Symfony GuzzleBundle
 
-[![Latest Stable Version](https://poser.pugx.org/eightpoints/guzzle-bundle/v/stable.png)](https://packagist.org/packages/eightpoints/guzzle-bundle)
 [![Total Downloads](https://poser.pugx.org/eightpoints/guzzle-bundle/downloads.png)](https://packagist.org/packages/eightpoints/guzzle-bundle)
+[![Monthly Downloads](https://poser.pugx.org/eightpoints/guzzle-bundle/d/monthly.png)](https://packagist.org/packages/eightpoints/guzzle-bundle)
+[![Latest Stable Version](https://poser.pugx.org/eightpoints/guzzle-bundle/v/stable.png)](https://packagist.org/packages/eightpoints/guzzle-bundle)
 [![Build Status](https://travis-ci.org/8p/GuzzleBundle.svg)](https://travis-ci.org/8p/GuzzleBundle)
-[![Dependency Status](https://www.versioneye.com/user/projects/57c83100968d640039516d62/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/57c83100968d640039516d62)
+[![License](https://poser.pugx.org/eightpoints/guzzle-bundle/license)](https://packagist.org/packages/eightpoints/guzzle-bundle)
+[![Dependency Status](https://www.versioneye.com/user/projects/57c83100968d640039516d62/badge.svg?style=square)](https://www.versioneye.com/user/projects/57c83100968d640039516d62)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/39a6e10b-ce29-44f6-97ce-44b2ff230424/mini.png)](https://insight.sensiolabs.com/projects/39a6e10b-ce29-44f6-97ce-44b2ff230424)
+
 
 
 This bundle integrates [Guzzle 6.x][1] into Symfony. Guzzle is a PHP framework for building RESTful web service clients.

--- a/Tests/DataCollector/HttpDataCollectorTest.php
+++ b/Tests/DataCollector/HttpDataCollectorTest.php
@@ -8,7 +8,7 @@ use EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector;
  * @version   2.1
  * @since     2015-05
  */
-class HttpDataCollectorTest extends \PHPUnit_Framework_TestCase
+class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \EightPoints\Bundle\GuzzleBundle\Log\Logger

--- a/Tests/DataCollector/HttpDataCollectorTest.php
+++ b/Tests/DataCollector/HttpDataCollectorTest.php
@@ -3,15 +3,20 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\DataCollector;
 
 use EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector;
+use EightPoints\Bundle\GuzzleBundle\Log\Logger;
+use EightPoints\Bundle\GuzzleBundle\Log\LogGroup;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @version   2.1
  * @since     2015-05
  */
-class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
+class HttpDataCollectorTest extends TestCase
 {
     /**
-     * @var \EightPoints\Bundle\GuzzleBundle\Log\Logger
+     * @var Logger
      */
     protected $logger;
 
@@ -23,7 +28,7 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
      */
     public function setUp()
     {
-        $this->logger = $this->getMockBuilder('EightPoints\Bundle\GuzzleBundle\Log\Logger')
+        $this->logger = $this->getMockBuilder(Logger::class)
                              ->getMock();
     }
 
@@ -33,16 +38,16 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::__construct
+     * @covers  HttpDataCollector::__construct
      */
     public function testConstruct()
     {
         $collector = new HttpDataCollector($this->logger);
         $data      = unserialize($collector->serialize());
-        $expected  = array(
-            'logs'      => array(),
+        $expected  = [
+            'logs'      => [],
             'callCount' => 0,
-        );
+        ];
 
         $this->assertSame($expected, $data);
     }
@@ -53,21 +58,26 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::collect
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getLogs
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getLogGroup
+     * @covers  HttpDataCollector::collect
+     * @covers  HttpDataCollector::getLogs
+     * @covers  HttpDataCollector::getLogGroup
      */
     public function testCollect()
     {
         $this->logger->expects($this->once())
                      ->method('getMessages')
-                     ->willReturn(array('test message'));
+                     ->willReturn(['test message']);
 
         $collector = new HttpDataCollector($this->logger);
-        $response  = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')
+        $response  = $this->getMockBuilder(Response::class)
                           ->getMock();
-        $request   = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+
+        $request = $this->getMockBuilder(Request::class)
                           ->getMock();
+
+        $request->expects($this->once())
+                ->method('getUri')
+                ->willReturn('someRandomUrlId');
 
         $request->expects($this->once())
                 ->method('getPathInfo')
@@ -77,12 +87,11 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
 
         $logs = $collector->getLogs();
 
-        /** @var \EightPoints\Bundle\GuzzleBundle\Log\LogGroup $log */
+        /** @var LogGroup $log */
         foreach ($logs as $log) {
+            $this->assertInstanceOf(LogGroup::class, $log);
 
-            $this->assertInstanceOf('EightPoints\Bundle\GuzzleBundle\Log\LogGroup', $log);
-
-            $this->assertSame(array('test message'), $log->getMessages());
+            $this->assertSame(['test message'], $log->getMessages());
             $this->assertSame('id', $log->getRequestName());
         }
     }
@@ -93,7 +102,7 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getName
+     * @covers  HttpDataCollector::getName
      */
     public function testName()
     {
@@ -108,7 +117,7 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getMessages
+     * @covers  HttpDataCollector::getMessages
      */
     public function testMessages()
     {
@@ -117,10 +126,14 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
                      ->willReturn(['test message #1', 'test message #2']);
 
         $collector = new HttpDataCollector($this->logger);
-        $response  = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')
+        $response  = $this->getMockBuilder(Response::class)
                           ->getMock();
-        $request   = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+        $request   = $this->getMockBuilder(Request::class)
                           ->getMock();
+
+        $request->expects($this->once())
+                ->method('getUri')
+                ->willReturn('someRandomUrlId');
 
         $request->expects($this->once())
                 ->method('getPathInfo')
@@ -144,7 +157,7 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getCallCount
+     * @covers  HttpDataCollector::getCallCount
      */
     public function testCallCount()
     {
@@ -153,10 +166,14 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
                      ->willReturn(['test message #1', 'test message #2']);
 
         $collector = new HttpDataCollector($this->logger);
-        $response  = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')
+        $response  = $this->getMockBuilder(Response::class)
                           ->getMock();
-        $request   = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+        $request   = $this->getMockBuilder(Request::class)
                           ->getMock();
+
+        $request->expects($this->once())
+                ->method('getUri')
+                ->willReturn('someRandomUrlId');
 
         $request->expects($this->once())
                 ->method('getPathInfo')
@@ -173,11 +190,11 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getErrorCount
+     * @covers  HttpDataCollector::getErrorCount
      */
     public function testErrorCount()
     {
-        // implement me
+        $this->markTestSkipped('must be implemented.');
     }
 
     /**
@@ -186,10 +203,10 @@ class HttpDataCollectorTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getTotalTime
+     * @covers  HttpDataCollector::getTotalTime
      */
     public function testTotalTime()
     {
-        // implement me
+        $this->markTestSkipped('must be implemented.');
     }
 }

--- a/Tests/DataCollector/HttpDataCollectorTest.php
+++ b/Tests/DataCollector/HttpDataCollectorTest.php
@@ -38,7 +38,7 @@ class HttpDataCollectorTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  HttpDataCollector::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::__construct
      */
     public function testConstruct()
     {
@@ -58,9 +58,9 @@ class HttpDataCollectorTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  HttpDataCollector::collect
-     * @covers  HttpDataCollector::getLogs
-     * @covers  HttpDataCollector::getLogGroup
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::collect
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getLogs
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getLogGroup
      */
     public function testCollect()
     {
@@ -102,7 +102,7 @@ class HttpDataCollectorTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  HttpDataCollector::getName
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getName
      */
     public function testName()
     {
@@ -117,7 +117,7 @@ class HttpDataCollectorTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  HttpDataCollector::getMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getMessages
      */
     public function testMessages()
     {
@@ -157,7 +157,7 @@ class HttpDataCollectorTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  HttpDataCollector::getCallCount
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getCallCount
      */
     public function testCallCount()
     {
@@ -190,7 +190,7 @@ class HttpDataCollectorTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  HttpDataCollector::getErrorCount
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getErrorCount
      */
     public function testErrorCount()
     {
@@ -203,7 +203,7 @@ class HttpDataCollectorTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  HttpDataCollector::getTotalTime
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::getTotalTime
      */
     public function testTotalTime()
     {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  * @version   2.1
  * @since     2015-05
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends \PHPUnit\Framework\TestCase
 {
     public function testSingleClientConfigWithOptions()
     {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection;
 
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
@@ -10,7 +11,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  * @version   2.1
  * @since     2015-05
  */
-class ConfigurationTest extends \PHPUnit\Framework\TestCase
+class ConfigurationTest extends TestCase
 {
     public function testSingleClientConfigWithOptions()
     {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -4,6 +4,7 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection;
 
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * @version   2.1
@@ -61,5 +62,88 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $processedConfig = $processor->processConfiguration(new Configuration(true), $config);
 
         $this->assertEquals(array_merge($config['guzzle'], ['logging' => false]), $processedConfig);
+    }
+
+    public function testSingleClientConfigWithCertAsArray()
+    {
+        $config = [
+            'guzzle' => [
+                'clients' => [
+                    'test_client' => [
+                        'base_url' => 'http://baseurl/path',
+                        'headers' => [
+                            'Accept' => 'application/json'
+                        ],
+                        'options' => [
+                            'auth' => [
+                                'user',
+                                'pass'
+                            ],
+                            'headers' => [
+                                'Accept' => 'application/json'
+                            ],
+                            'query' => [
+                            ],
+                            'cert' => [
+                                'path/to/cert',
+                                'password'
+                            ],
+                            'connect_timeout' => 5,
+                            'debug' => false,
+                            'decode_content' => true,
+                            'delay' => 1,
+                            'http_errors' => false,
+                            'expect' => true,
+                            'ssl_key' => 'key',
+                            'stream' => true,
+                            'synchronous' => true,
+                            'timeout' => 30,
+                            'verify' => true,
+                            'version' => '1.1'
+                        ],
+                        'plugin' => [
+                            'wsse' => [
+                                'username' => 'user',
+                                'password' => 'pass',
+                                'created_at' => false
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $processor = new Processor();
+        $processedConfig = $processor->processConfiguration(new Configuration(true), $config);
+
+        $this->assertEquals(array_merge($config['guzzle'], ['logging' => false]), $processedConfig);
+    }
+
+    public function testInvalidCertConfiguration()
+    {
+        $config = [
+            'guzzle' => [
+                'clients' => [
+                    'test_client' => [
+                        'base_url' => 'http://baseurl/path',
+                        'headers' => [
+                            'Accept' => 'application/json'
+                        ],
+                        'options' => [
+                            'cert' => [
+                                'path/to/cert',
+                                'password',
+                                'Invalid'
+                            ],
+                        ],
+                    ]
+                ]
+            ]
+        ];
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $processor = new Processor();
+        $processor->processConfiguration(new Configuration(true), $config);
     }
 }

--- a/Tests/DependencyInjection/GuzzleExtensionTest.php
+++ b/Tests/DependencyInjection/GuzzleExtensionTest.php
@@ -8,13 +8,15 @@ use EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection\Fixtures\FakeClien
 use EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection\Fixtures\FakeWsseAuthMiddleware;
 use EightPoints\Guzzle\WsseAuthMiddleware;
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @version 2.1
  * @since   2015-05
  */
-class GuzzleExtensionTest extends \PHPUnit\Framework\TestCase
+class GuzzleExtensionTest extends TestCase
 {
     public function testGuzzleExtension()
     {
@@ -76,7 +78,7 @@ class GuzzleExtensionTest extends \PHPUnit\Framework\TestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
-        $container->set('event_dispatcher', $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
+        $container->set('event_dispatcher', $this->createMock(EventDispatcherInterface::class));
 
         return $container;
     }

--- a/Tests/DependencyInjection/GuzzleExtensionTest.php
+++ b/Tests/DependencyInjection/GuzzleExtensionTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @version 2.1
  * @since   2015-05
  */
-class GuzzleExtensionTest extends \PHPUnit_Framework_TestCase
+class GuzzleExtensionTest extends \PHPUnit\Framework\TestCase
 {
     public function testGuzzleExtension()
     {

--- a/Tests/Events/PostTransactionEventTest.php
+++ b/Tests/Events/PostTransactionEventTest.php
@@ -18,7 +18,7 @@ class PostTransactionEventTest extends TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers PostTransactionEvent::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::__construct
      */
     public function testConstruct()
     {
@@ -35,8 +35,8 @@ class PostTransactionEventTest extends TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers PostTransactionEvent::setTransaction
-     * @covers PostTransactionEvent::getTransaction
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::setTransaction
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::getTransaction
      */
     public function testTransaction()
     {

--- a/Tests/Events/PostTransactionEventTest.php
+++ b/Tests/Events/PostTransactionEventTest.php
@@ -8,7 +8,7 @@ use EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent;
  * @version   4.5
  * @since     2016-01
  */
-class PostTransactionEventTest extends \PHPUnit_Framework_TestCase
+class PostTransactionEventTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test Instance
@@ -16,7 +16,7 @@ class PostTransactionEventTest extends \PHPUnit_Framework_TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::__construct
      */
     public function testConstruct()
     {
@@ -33,8 +33,8 @@ class PostTransactionEventTest extends \PHPUnit_Framework_TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::setTransaction
-     * @covers  EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::getTransaction
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::setTransaction
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::getTransaction
      */
     public function testTranscation()
     {

--- a/Tests/Events/PostTransactionEventTest.php
+++ b/Tests/Events/PostTransactionEventTest.php
@@ -3,12 +3,14 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Events;
 
 use EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Response;
 
 /**
  * @version   4.5
  * @since     2016-01
  */
-class PostTransactionEventTest extends \PHPUnit\Framework\TestCase
+class PostTransactionEventTest extends TestCase
 {
     /**
      * Test Instance
@@ -16,12 +18,12 @@ class PostTransactionEventTest extends \PHPUnit\Framework\TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::__construct
+     * @covers PostTransactionEvent::__construct
      */
     public function testConstruct()
     {
         $serviceName = 'service name';
-        $response    = $this->createMock('GuzzleHttp\Psr7\Response');
+        $response    = $this->createMock(Response::class);
         $postEvent   = new PostTransactionEvent($response, $serviceName);
 
         $this->assertSame($serviceName, $postEvent->getServiceName());
@@ -33,16 +35,16 @@ class PostTransactionEventTest extends \PHPUnit\Framework\TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::setTransaction
-     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::getTransaction
+     * @covers PostTransactionEvent::setTransaction
+     * @covers PostTransactionEvent::getTransaction
      */
-    public function testTranscation()
+    public function testTransaction()
     {
         $statusCode = 204;
-        $response   = $this->createMock('GuzzleHttp\Psr7\Response');
-        $postEvent  = new PostTransactionEvent($response, null);
+        $response   = $this->createMock(Response::class);
+        $postEvent  = new PostTransactionEvent($response, 'main');
 
-        $transMock = $this->getMockBuilder('GuzzleHttp\Psr7\Response')
+        $transMock = $this->getMockBuilder(Response::class)
                           ->getMock();
 
         $transMock->method('getStatusCode')->willReturn($statusCode);

--- a/Tests/Events/PreTransactionEventTest.php
+++ b/Tests/Events/PreTransactionEventTest.php
@@ -18,7 +18,7 @@ class PreTransactionEventTest extends TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers PreTransactionEvent::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::__construct
      */
     public function testConstruct()
     {

--- a/Tests/Events/PreTransactionEventTest.php
+++ b/Tests/Events/PreTransactionEventTest.php
@@ -3,12 +3,14 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Events;
 
 use EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent;
+use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @version   4.5
  * @since     2016-01
  */
-class PreTransactionEventTest extends \PHPUnit\Framework\TestCase
+class PreTransactionEventTest extends TestCase
 {
     /**
      * Test Instance
@@ -16,13 +18,13 @@ class PreTransactionEventTest extends \PHPUnit\Framework\TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::__construct
+     * @covers PreTransactionEvent::__construct
      */
     public function testConstruct()
     {
         $serviceName = 'service name';
-        $request     = $this->getMockBuilder('GuzzleHttp\Psr7\Request')
-                            ->setConstructorArgs(array('GET', '/'))
+        $request     = $this->getMockBuilder(Request::class)
+                            ->setConstructorArgs(['GET', '/'])
                             ->getMock();
 
         $preEvent = new PreTransactionEvent($request, $serviceName);
@@ -39,17 +41,17 @@ class PreTransactionEventTest extends \PHPUnit\Framework\TestCase
      * @covers \EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::setTransaction
      * @covers \EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::getTransaction
      */
-    public function testTranscation()
+    public function testTransaction()
     {
         $method   = 'POST';
-        $request  = $this->getMockBuilder('GuzzleHttp\Psr7\Request')
-                         ->setConstructorArgs(array('GET', '/'))
+        $request  = $this->getMockBuilder(Request::class)
+                         ->setConstructorArgs(['GET', '/'])
                          ->getMock();
 
-        $preEvent = new PreTransactionEvent($request, null);
+        $preEvent = new PreTransactionEvent($request, 'main');
 
-        $transMock = $this->getMockBuilder('GuzzleHttp\Psr7\Request')
-                          ->setConstructorArgs(array($method, '/'))
+        $transMock = $this->getMockBuilder(Request::class)
+                          ->setConstructorArgs([$method, '/'])
                           ->getMock();
 
         $transMock->method('getMethod')->willReturn($method);

--- a/Tests/Events/PreTransactionEventTest.php
+++ b/Tests/Events/PreTransactionEventTest.php
@@ -8,7 +8,7 @@ use EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent;
  * @version   4.5
  * @since     2016-01
  */
-class PreTransactionEventTest extends \PHPUnit_Framework_TestCase
+class PreTransactionEventTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test Instance
@@ -16,7 +16,7 @@ class PreTransactionEventTest extends \PHPUnit_Framework_TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::__construct
      */
     public function testConstruct()
     {
@@ -36,8 +36,8 @@ class PreTransactionEventTest extends \PHPUnit_Framework_TestCase
      * @version 4.5
      * @since   2016-01
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::setTransaction
-     * @covers  EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::getTransaction
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::setTransaction
+     * @covers \EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent::getTransaction
      */
     public function testTranscation()
     {

--- a/Tests/Log/LogGroupTest.php
+++ b/Tests/Log/LogGroupTest.php
@@ -3,12 +3,14 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
 
 use EightPoints\Bundle\GuzzleBundle\Log\LogGroup;
+use EightPoints\Bundle\GuzzleBundle\Log\LogMessage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @version   2.1
  * @since     2015-05
  */
-class LogGroupTest extends \PHPUnit\Framework\TestCase
+class LogGroupTest extends TestCase
 {
     /**
      * Test Setting/Returning Request Name
@@ -16,8 +18,8 @@ class LogGroupTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::setRequestName
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::getRequestName
+     * @covers LogGroup::setRequestName
+     * @covers LogGroup::getRequestName
      */
     public function testRequestName()
     {
@@ -36,9 +38,9 @@ class LogGroupTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers  \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::setMessages
-     * @covers  \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::getMessages
-     * @covers  \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::addMessages
+     * @covers  LogGroup::setMessages
+     * @covers  LogGroup::getMessages
+     * @covers  LogGroup::addMessages
      */
     public function testMessages()
     {
@@ -47,15 +49,15 @@ class LogGroupTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(is_array($group->getMessages()));
         $this->assertEmpty($group->getMessages());
 
-        $message1 = $this->getMockBuilder('EightPoints\Bundle\GuzzleBundle\Log\LogMessage')
+        $message1 = $this->getMockBuilder(LogMessage::class)
                          ->disableOriginalConstructor()
                          ->getMock();
 
-        $message2 = $this->getMockBuilder('EightPoints\Bundle\GuzzleBundle\Log\LogMessage')
+        $message2 = $this->getMockBuilder(LogMessage::class)
                          ->disableOriginalConstructor()
                          ->getMock();
 
-        $message3 = $this->getMockBuilder('EightPoints\Bundle\GuzzleBundle\Log\LogMessage')
+        $message3 = $this->getMockBuilder(LogMessage::class)
                          ->disableOriginalConstructor()
                          ->getMock();
 
@@ -70,7 +72,7 @@ class LogGroupTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(3, $group->getMessages());
 
         foreach($group->getMessages() as $message) {
-            $this->assertInstanceOf('EightPoints\Bundle\GuzzleBundle\Log\LogMessage', $message);
+            $this->assertInstanceOf(LogMessage::class, $message);
         }
 
         // reset messages

--- a/Tests/Log/LogGroupTest.php
+++ b/Tests/Log/LogGroupTest.php
@@ -18,8 +18,8 @@ class LogGroupTest extends TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers LogGroup::setRequestName
-     * @covers LogGroup::getRequestName
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::setRequestName
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::getRequestName
      */
     public function testRequestName()
     {
@@ -38,9 +38,9 @@ class LogGroupTest extends TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers  LogGroup::setMessages
-     * @covers  LogGroup::getMessages
-     * @covers  LogGroup::addMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::setMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::getMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::addMessages
      */
     public function testMessages()
     {

--- a/Tests/Log/LogGroupTest.php
+++ b/Tests/Log/LogGroupTest.php
@@ -8,7 +8,7 @@ use EightPoints\Bundle\GuzzleBundle\Log\LogGroup;
  * @version   2.1
  * @since     2015-05
  */
-class LogGroupTest extends \PHPUnit_Framework_TestCase
+class LogGroupTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test Setting/Returning Request Name
@@ -16,8 +16,8 @@ class LogGroupTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogGroup::setRequestName
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogGroup::getRequestName
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::setRequestName
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::getRequestName
      */
     public function testRequestName()
     {
@@ -36,8 +36,8 @@ class LogGroupTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogGroup::setMessages
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogGroup::getMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::setMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogGroup::getMessages
      */
     public function testMessages()
     {

--- a/Tests/Log/LogMessageTest.php
+++ b/Tests/Log/LogMessageTest.php
@@ -6,7 +6,7 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
  * @version   2.1
  * @since     2015-05
  */
-class LogMessageTest extends \PHPUnit_Framework_TestCase
+class LogMessageTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {

--- a/Tests/Log/LogMessageTest.php
+++ b/Tests/Log/LogMessageTest.php
@@ -3,12 +3,13 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
 
 use EightPoints\Bundle\GuzzleBundle\Log\LogMessage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @version   2.1
  * @since     2015-05
  */
-class LogMessageTest extends \PHPUnit\Framework\TestCase
+class LogMessageTest extends TestCase
 {
     public function testConstruct()
     {

--- a/Tests/Log/LogRequestTest.php
+++ b/Tests/Log/LogRequestTest.php
@@ -4,6 +4,7 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
 
 use EightPoints\Bundle\GuzzleBundle\Log\LogRequest;
 use GuzzleHttp\Psr7\Stream;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -11,7 +12,7 @@ use Psr\Http\Message\UriInterface;
  * @version   2.1
  * @since     2015-05
  */
-class LogRequestTest extends \PHPUnit\Framework\TestCase
+class LogRequestTest extends TestCase
 {
     /** @var RequestInterface */
     protected $request;

--- a/Tests/Log/LogRequestTest.php
+++ b/Tests/Log/LogRequestTest.php
@@ -6,7 +6,7 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
  * @version   2.1
  * @since     2015-05
  */
-class LogRequestTest extends \PHPUnit_Framework_TestCase
+class LogRequestTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {

--- a/Tests/Log/LogResponseTest.php
+++ b/Tests/Log/LogResponseTest.php
@@ -3,21 +3,20 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
 
 use EightPoints\Bundle\GuzzleBundle\Log\LogResponse;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
 
 /**
  * @version   2.1
  * @since     2015-05
  */
-class LogResponseTest extends \PHPUnit\Framework\TestCase
+class LogResponseTest extends TestCase
 {
-    /**
-     * @var \GuzzleHttp\Psr7\Response
-     */
+    /** @var Response */
     protected $response;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $headers = [
         'Date'          => ['Sun, 07 Jun 2015 16:32:50 GMT'],
         'Expires'       => ['-1'],
@@ -33,11 +32,11 @@ class LogResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function setUp()
     {
-        $this->response = $this->getMockBuilder('GuzzleHttp\Psr7\Response')
+        $this->response = $this->getMockBuilder(Response::class)
                                ->disableOriginalConstructor()
                                ->getMock();
 
-        $bodyMock = $this->getMockBuilder('GuzzleHttp\Psr7\Stream')
+        $bodyMock = $this->getMockBuilder(Stream::class)
                          ->disableOriginalConstructor()
                          ->getMock();
 
@@ -55,10 +54,10 @@ class LogResponseTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getStatusCode
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setStatusCode
+     * @covers LogResponse::__construct
+     * @covers LogResponse::save
+     * @covers LogResponse::getStatusCode
+     * @covers LogResponse::setStatusCode
      */
     public function testStatusCode()
     {
@@ -73,10 +72,10 @@ class LogResponseTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getBody
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setBody
+     * @covers LogResponse::__construct
+     * @covers LogResponse::save
+     * @covers LogResponse::getBody
+     * @covers LogResponse::setBody
      */
     public function testBody()
     {
@@ -91,10 +90,10 @@ class LogResponseTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getProtocolVersion
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setProtocolVersion
+     * @covers LogResponse::__construct
+     * @covers LogResponse::save
+     * @covers LogResponse::getProtocolVersion
+     * @covers LogResponse::setProtocolVersion
      */
     public function testProtocolVersion()
     {
@@ -109,10 +108,10 @@ class LogResponseTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getHeaders
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setHeaders
+     * @covers LogResponse::__construct
+     * @covers LogResponse::save
+     * @covers LogResponse::getHeaders
+     * @covers LogResponse::setHeaders
      */
     public function testHeaders()
     {

--- a/Tests/Log/LogResponseTest.php
+++ b/Tests/Log/LogResponseTest.php
@@ -54,10 +54,10 @@ class LogResponseTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers LogResponse::__construct
-     * @covers LogResponse::save
-     * @covers LogResponse::getStatusCode
-     * @covers LogResponse::setStatusCode
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getStatusCode
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setStatusCode
      */
     public function testStatusCode()
     {
@@ -72,10 +72,10 @@ class LogResponseTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers LogResponse::__construct
-     * @covers LogResponse::save
-     * @covers LogResponse::getBody
-     * @covers LogResponse::setBody
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getBody
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setBody
      */
     public function testBody()
     {
@@ -90,10 +90,10 @@ class LogResponseTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers LogResponse::__construct
-     * @covers LogResponse::save
-     * @covers LogResponse::getProtocolVersion
-     * @covers LogResponse::setProtocolVersion
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getProtocolVersion
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setProtocolVersion
      */
     public function testProtocolVersion()
     {
@@ -108,10 +108,10 @@ class LogResponseTest extends TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers LogResponse::__construct
-     * @covers LogResponse::save
-     * @covers LogResponse::getHeaders
-     * @covers LogResponse::setHeaders
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getHeaders
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setHeaders
      */
     public function testHeaders()
     {

--- a/Tests/Log/LogResponseTest.php
+++ b/Tests/Log/LogResponseTest.php
@@ -8,7 +8,7 @@ use EightPoints\Bundle\GuzzleBundle\Log\LogResponse;
  * @version   2.1
  * @since     2015-05
  */
-class LogResponseTest extends \PHPUnit_Framework_TestCase
+class LogResponseTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \GuzzleHttp\Psr7\Response
@@ -55,10 +55,10 @@ class LogResponseTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getStatusCode
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setStatusCode
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getStatusCode
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setStatusCode
      */
     public function testStatusCode()
     {
@@ -73,10 +73,10 @@ class LogResponseTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getBody
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setBody
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getBody
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setBody
      */
     public function testBody()
     {
@@ -91,10 +91,10 @@ class LogResponseTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getProtocolVersion
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setProtocolVersion
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getProtocolVersion
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setProtocolVersion
      */
     public function testProtocolVersion()
     {
@@ -109,10 +109,10 @@ class LogResponseTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-06
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getHeaders
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setHeaders
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::save
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::getHeaders
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\LogResponse::setHeaders
      */
     public function testHeaders()
     {

--- a/Tests/Log/LoggerTest.php
+++ b/Tests/Log/LoggerTest.php
@@ -26,7 +26,7 @@ class LoggerTest extends TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers  Logger::__construct
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::__construct
      */
     public function testConstruct()
     {
@@ -39,7 +39,7 @@ class LoggerTest extends TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers Logger::hasMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::hasMessages
      */
     public function testHasMessages()
     {
@@ -56,7 +56,7 @@ class LoggerTest extends TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers Logger::getMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::getMessages
      */
     public function testGetMessages()
     {
@@ -106,7 +106,7 @@ class LoggerTest extends TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers Logger::clear
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::clear
      */
     public function testClear()
     {

--- a/Tests/Log/LoggerTest.php
+++ b/Tests/Log/LoggerTest.php
@@ -25,8 +25,6 @@ class LoggerTest extends TestCase
      *
      * @version 2.1
      * @since   2015-05
-     *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::__construct
      */
     public function testConstruct()
     {

--- a/Tests/Log/LoggerTest.php
+++ b/Tests/Log/LoggerTest.php
@@ -13,7 +13,7 @@ use EightPoints\Bundle\GuzzleBundle\Log\LogMessage;
  * @version   2.1
  * @since     2015-05
  */
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test Instance
@@ -34,7 +34,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\Logger::hasMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::hasMessages
      */
     public function testHasMessages()
     {
@@ -51,7 +51,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\Logger::getMessages
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::getMessages
      */
     public function testGetMessages()
     {
@@ -102,7 +102,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers  EightPoints\Bundle\GuzzleBundle\Log\Logger::clear
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::clear
      */
     public function testClear()
     {

--- a/Tests/Log/LoggerTest.php
+++ b/Tests/Log/LoggerTest.php
@@ -3,7 +3,12 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
 
 use EightPoints\Bundle\GuzzleBundle\Log\Logger;
+use EightPoints\Bundle\GuzzleBundle\Log\LoggerInterface;
 use EightPoints\Bundle\GuzzleBundle\Log\LogMessage;
+use EightPoints\Bundle\GuzzleBundle\Log\LogRequest;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class LoggerTest
@@ -13,7 +18,7 @@ use EightPoints\Bundle\GuzzleBundle\Log\LogMessage;
  * @version   2.1
  * @since     2015-05
  */
-class LoggerTest extends \PHPUnit\Framework\TestCase
+class LoggerTest extends TestCase
 {
     /**
      * Test Instance
@@ -21,11 +26,11 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * covers  EightPoints\Bundle\GuzzleBundle\Log\Logger::__construct
+     * @covers  Logger::__construct
      */
     public function testConstruct()
     {
-        $this->assertInstanceOf('EightPoints\Bundle\GuzzleBundle\Log\LoggerInterface', new Logger());
+        $this->assertInstanceOf(LoggerInterface::class, new Logger());
     }
 
     /**
@@ -34,7 +39,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::hasMessages
+     * @covers Logger::hasMessages
      */
     public function testHasMessages()
     {
@@ -51,7 +56,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::getMessages
+     * @covers Logger::getMessages
      */
     public function testGetMessages()
     {
@@ -68,19 +73,18 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
 
         /** @var LogMessage $message */
         foreach ($messages as $message) {
-
-            $this->assertInstanceOf('EightPoints\Bundle\GuzzleBundle\Log\LogMessage', $message);
+            $this->assertInstanceOf(LogMessage::class, $message);
             $this->assertSame('test', $message->getLevel());
             $this->assertContains('test message', $message->getMessage());
             $this->assertNull($message->getRequest());
             $this->assertNull($message->getResponse());
         }
 
-        $uriMock = $this->getMockBuilder('GuzzleHttp\Psr7\Uri')
+        $uriMock = $this->getMockBuilder(Uri::class)
                             ->disableOriginalConstructor()
                             ->getMock();
 
-        $requestMock = $this->getMockBuilder('GuzzleHttp\Psr7\Request')
+        $requestMock = $this->getMockBuilder(Request::class)
                             ->disableOriginalConstructor()
                             ->getMock();
 
@@ -93,7 +97,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('info', $message->getLevel());
         $this->assertSame('info message', $message->getMessage());
 
-        $this->assertInstanceOf('EightPoints\Bundle\GuzzleBundle\Log\LogRequest', $message->getRequest());
+        $this->assertInstanceOf(LogRequest::class, $message->getRequest());
     }
 
     /**
@@ -102,7 +106,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
      * @version 2.1
      * @since   2015-05
      *
-     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::clear
+     * @covers Logger::clear
      */
     public function testClear()
     {

--- a/Tests/Middleware/EventDispatchMiddlewareTest.php
+++ b/Tests/Middleware/EventDispatchMiddlewareTest.php
@@ -5,11 +5,12 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\Middleware;
 use EightPoints\Bundle\GuzzleBundle\Middleware\EventDispatchMiddleware;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\RejectedPromise;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class EventDispatchMiddlewareTest extends \PHPUnit_Framework_TestCase
+class EventDispatchMiddlewareTest extends TestCase
 {
     /** @var EventDispatcher */
     private $eventDispatcher;

--- a/Tests/Middleware/LogMiddlewareTest.php
+++ b/Tests/Middleware/LogMiddlewareTest.php
@@ -7,10 +7,11 @@ use EightPoints\Bundle\GuzzleBundle\Log\LoggerInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Promise\RejectedPromise;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class LogMiddlewareTest extends \PHPUnit_Framework_TestCase
+class LogMiddlewareTest extends TestCase
 {
     /** @var LoggerInterface */
     protected $logger;

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     }
   ],
   "require": {
-    "php":                                ">=5.6",
+    "php":                                ">=7.0",
     "guzzlehttp/guzzle":                  "~6.0",
     "eightpoints/guzzle-wsse-middleware": "~4.0",
     "symfony/dependency-injection":       "~2.3|~3.0",
@@ -36,7 +36,7 @@
     "psr/log":                            "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.4",
+    "phpunit/phpunit": "~6.1",
     "symfony/config":  "2.3|~3.0"
   },
   "target-dir": "EightPoints/Bundle/GuzzleBundle",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" bootstrap="vendor/autoload.php" colors="true"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd">
+		 xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd">
 	<testsuites>
 		<testsuite name="GuzzleBundle Test Suite">
 			<directory>./Tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" bootstrap="vendor/autoload.php" colors="true"
+<phpunit backupGlobals="false"
+		 bootstrap="vendor/autoload.php"
+		 colors="true"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd">
+		 xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+>
 	<testsuites>
 		<testsuite name="GuzzleBundle Test Suite">
 			<directory>./Tests</directory>


### PR DESCRIPTION
- [x] Bug fix
- [ ] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Fixed tickets: [#96]
License: MIT

What I did:
- [x] Add parameters type hinting
- [x] array() to []
- [x] Add classes to use
- [x] Return type to methods
- [x] Readme
- [x] Fix tests
- [x] Fix comments
- [x] Fix typos
- [x] Fix code style