### PR TITLE
Add plugin system and remove dependency on wsse package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 
 
 This bundle integrates [Guzzle 6.x][1] into Symfony. Guzzle is a PHP framework for building RESTful web service clients.
-It comes with a WSSE Auth Plugin that can be used optionally.
 
 GuzzleBundle follows semantic versioning. Read more on [semver.org][2].
 
@@ -30,7 +29,6 @@ GuzzleBundle follows semantic versioning. Read more on [semver.org][2].
  - PHP 7.0 or above
  - Symfony 2.7 or above
  - [Guzzle PHP Framework][1] (included by composer)
- - [WSSE Auth Plugin][3] (included by composer)
 
 ----
 
@@ -86,11 +84,7 @@ eight_points_guzzle:
                 timeout: 30
 
             # plugin settings
-            plugin:
-                wsse:
-                    username:   "acme"
-                    password:   "pa55w0rd"
-                    created_at: "-10 seconds" # optional
+            plugin: ~
 
         api_crm:
             base_url: "http://api.crm.tld"
@@ -99,7 +93,7 @@ eight_points_guzzle:
 
         ...
 ```
-All these settings are optional. If WSSE username is defined the WSSE plugin will be injected automatically.
+All these settings are optional.
 
 Using services in controller (eight_points_guzzle.client.**api_crm** represents the client name of the yaml config and is an instance of GuzzleHttp\Client):
 ``` php
@@ -124,6 +118,9 @@ Events dispatched are eight_points_guzzle.pre_transaction, eight_points_guzzle.p
 The service on the tag, is so that if you have multiple REST endpoints you can define which service a particular listener is interested in.
 
 ----
+
+## Plugins
+WSSE - https://github.com/8p/guzzle-wsse-plugin
 
 ## Features
 ### Symfony Debug Toolbar / Profiler

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
   "require": {
     "php":                                ">=7.0",
     "guzzlehttp/guzzle":                  "~6.0",
-    "eightpoints/guzzle-wsse-middleware": "~4.0",
     "symfony/dependency-injection":       "~2.3|~3.0",
     "symfony/expression-language":        "~2.3|~3.0",
     "symfony/event-dispatcher":           "~2.3|~3.0",

--- a/src/EightPointsGuzzleBundle.php
+++ b/src/EightPointsGuzzleBundle.php
@@ -14,6 +14,17 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
  */
 class EightPointsGuzzleBundle extends Bundle
 {
+    /** @var array */
+    protected $plugins = [];
+
+    /**
+     * @param array $plugins
+     */
+    public function __construct(array $plugins = [])
+    {
+        $this->plugins = $plugins;
+    }
+
     /**
      * Build EightPointsGuzzleBundle
      *
@@ -27,8 +38,11 @@ class EightPointsGuzzleBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new EventHandlerCompilerPass());
+        foreach ($this->plugins as $plugin) {
+            $plugin->build($container);
+        }
 
+        $container->addCompilerPass(new EventHandlerCompilerPass());
     }
 
     /**
@@ -48,11 +62,11 @@ class EightPointsGuzzleBundle extends Bundle
     {
         if (null === $this->extension) {
 
-            $extension = new EightPointsGuzzleExtension();
+            $extension = new EightPointsGuzzleExtension($this->plugins);
 
             if (!$extension instanceof ExtensionInterface) {
 
-                $message = sprintf('%s is not a instance of ExtensionInterface', $extension->getClass());
+                $message = sprintf('%s is not a instance of ExtensionInterface', get_class($extension));
 
                 throw new \LogicException($message);
             }
@@ -61,5 +75,12 @@ class EightPointsGuzzleBundle extends Bundle
         }
 
         return $this->extension;
+    }
+
+    public function boot()
+    {
+        foreach ($this->plugins as $plugin) {
+            $plugin->boot($this->container);
+        }
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -16,10 +16,6 @@
         <parameter key="eight_points_guzzle.middleware.event_dispatcher.class">EightPoints\Bundle\GuzzleBundle\Middleware\EventDispatchMiddleware</parameter>
 
         <parameter key="eight_points_guzzle.plugin.header.headers" type="collection" />
-
-        <parameter key="eight_points_guzzle.middleware.wsse.class">EightPoints\Guzzle\WsseAuthMiddleware</parameter>
-        <parameter key="eight_points_guzzle.plugin.wsse.username" />
-        <parameter key="eight_points_guzzle.plugin.wsse.password" />
     </parameters>
 
     <services>

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -52,13 +52,7 @@ class ConfigurationTest extends TestCase
                             ],
                             'version' => '1.1'
                         ],
-                        'plugin' => [
-                            'wsse' => [
-                                'username' => 'user',
-                                'password' => 'pass',
-                                'created_at' => false
-                            ]
-                        ],
+                        'plugin' => [],
 						'class' => '%eight_points_guzzle_bundle.http_client.class%',
                     ]
                 ]
@@ -108,13 +102,7 @@ class ConfigurationTest extends TestCase
                             'verify' => true,
                             'version' => '1.1'
                         ],
-                        'plugin' => [
-                            'wsse' => [
-                                'username' => 'user',
-                                'password' => 'pass',
-                                'created_at' => false
-                            ]
-                        ],
+                        'plugin' => [],
 						'class' => '%eight_points_guzzle_bundle.http_client.class%',
                     ]
                 ]
@@ -177,13 +165,7 @@ class ConfigurationTest extends TestCase
                             ],
                             'proxy' => 'http://proxy.org'
                         ],
-                        'plugin' => [
-                            'wsse' => [
-                                'username' => 'user',
-                                'password' => 'pass',
-                                'created_at' => false
-                            ]
-                        ],
+                        'plugin' => [],
 						'class' => '%eight_points_guzzle_bundle.http_client.class%',
                     ]
                 ]

--- a/tests/DependencyInjection/GuzzleExtensionTest.php
+++ b/tests/DependencyInjection/GuzzleExtensionTest.php
@@ -34,13 +34,6 @@ class GuzzleExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.log.test_api'));
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.event_dispatch.test_api'));
 
-        // test WSSE Plugin
-        $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.wsse.test_api'));
-        $wsse = $container->get('eight_points_guzzle.middleware.wsse.test_api');
-        $this->assertInstanceOf(WsseAuthMiddleware::class, $wsse);
-        $this->assertSame('my-user', $wsse->getUsername());
-        $this->assertSame('my-pass', $wsse->getPassword());
-
         // test Client with custom class
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.client.test_api_with_custom_class'));
         $definition = $container->getDefinition('eight_points_guzzle.client.test_api_with_custom_class');
@@ -54,13 +47,9 @@ class GuzzleExtensionTest extends TestCase
         $extension->load($this->getConfigs(), $container);
 
         $container->setParameter('eight_points_guzzle.http_client.class', FakeClient::class);
-        $container->setParameter('eight_points_guzzle.middleware.wsse.class', FakeWsseAuthMiddleware::class);
 
         $client = $container->get('eight_points_guzzle.client.test_api', FakeClient::class);
         $this->assertInstanceOf(FakeClient::class, $client);
-
-        $wsse = $container->get('eight_points_guzzle.middleware.wsse.test_api');
-        $this->assertInstanceOf(FakeWsseAuthMiddleware::class, $wsse);
     }
 
     public function testGetConfiguration()
@@ -93,12 +82,7 @@ class GuzzleExtensionTest extends TestCase
                 'clients' => [
                     'test_api' => [
                         'base_url' => '//api.domain.tld/path',
-                        'plugin' => [
-                            'wsse' => [
-                                'username' => 'my-user',
-                                'password' => 'my-pass',
-                            ],
-                        ],
+                        'plugin' => [],
                     ],
                     'test_api_with_custom_class' => [
                         'class' => 'CustomGuzzleClass',


### PR DESCRIPTION
- [ ] Bug fix
- [x] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Fixed tickets: [#73]
License: MIT

This pull request is a concept, how to make wsse plugin optional in guzzle bundle.
Linked PR: https://github.com/8p/guzzle-wsse-middleware/pull/13
Inspired from: https://matthiasnoback.nl/2015/07/a-plugin-system-for-bundles/
Usage: all plugins will be activated/connected through GuzzleBundle constructor in AppKernel, like this:
``` php
new EightPoints\Bundle\GuzzleBundle\GuzzleBundle([
    new EightPoints\Bundle\GuzzleWsseBundle\GuzzleWsseBundle(),
])
```

Important! It's not finished, it's a concept. I didn't test it. I want to see any feedback, suggestion, criticism or questions :)